### PR TITLE
Alternative Wait For Vite Server

### DIFF
--- a/src/Vite.AspNetCore/Services/ViteDevMiddleware.cs
+++ b/src/Vite.AspNetCore/Services/ViteDevMiddleware.cs
@@ -117,7 +117,7 @@ namespace Vite.AspNetCore.Services
         public async Task InvokeAsync(HttpContext context, RequestDelegate next)
         {
             var initializationTask = this._initializationTask;
-            if (initializationTask is not null)
+            if (initializationTask != null)
             {
                 // Wait until initialization is complete before passing the request to next middleware
                 await initializationTask;


### PR DESCRIPTION
This approach uses Tasks as to not sleep the thread we're waiting on. This ensures we don't get into deadlock scenarios.

It also adds infrastructure for more startup tasks if they are ever needed in the future.