### PR TITLE
Fix issue with NodeScriptRunner.cs Dispose

### DIFF
--- a/src/Vite.AspNetCore/Utilities/NodeScriptRunner.cs
+++ b/src/Vite.AspNetCore/Utilities/NodeScriptRunner.cs
@@ -12,95 +12,94 @@ namespace Vite.AspNetCore.Utilities;
 /// </summary>
 internal sealed class NodeScriptRunner : IDisposable
 {
-	private readonly ILogger _logger;
-	private readonly Process? _npmProcess;
-	private readonly NodeStreamReader _stdOutReader;
-	private readonly NodeStreamReader _stdErrorReader;
+    private readonly ILogger _logger;
+    private readonly Process? _npmProcess;
+    private readonly NodeStreamReader _stdOutReader;
+    private readonly NodeStreamReader _stdErrorReader;
 
-	/// <summary>
-	/// Initializes a new instance of the <see cref="NodeScriptRunner"/> class.
-	/// </summary>
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NodeScriptRunner"/> class.
+    /// </summary>
 	public NodeScriptRunner(ILogger logger, string pkgManagerCommand, string scriptName, string workingDirectory, CancellationToken cancellationToken = default)
-	{
-		this._logger = logger;
-		// If the package manager command is null or empty, throw an exception.
-		if (string.IsNullOrEmpty(pkgManagerCommand))
-		{
+    {
+        this._logger = logger;
+        // If the package manager command is null or empty, throw an exception.
+        if (string.IsNullOrEmpty(pkgManagerCommand))
+        {
 			throw new ArgumentNullException(nameof(pkgManagerCommand), "The package manager command cannot be null or empty.");
-		}
-		// If the script name is null or empty, throw an exception.
-		if (string.IsNullOrEmpty(scriptName))
-		{
-			throw new ArgumentNullException(nameof(scriptName), "The script name cannot be null or empty.");
-		}
-		// If the working directory is null or empty, throw an exception.
-		if (string.IsNullOrEmpty(workingDirectory))
-		{
-			throw new ArgumentNullException(nameof(workingDirectory), "The working directory cannot be null or empty.");
-		}
+        }
+        // If the script name is null or empty, throw an exception.
+        if (string.IsNullOrEmpty(scriptName))
+        {
+            throw new ArgumentNullException(nameof(scriptName), "The script name cannot be null or empty.");
+        }
+        // If the working directory is null or empty, throw an exception.
+        if (string.IsNullOrEmpty(workingDirectory))
+        {
+            throw new ArgumentNullException(nameof(workingDirectory), "The working directory cannot be null or empty.");
+        }
 
-		// Set the command to run.
-		var exeToRun = pkgManagerCommand;
-		// Set the arguments.
-		var args = $"run {scriptName}";
+        // Set the command to run.
+        var exeToRun = pkgManagerCommand;
+        // Set the arguments.
+        var args = $"run {scriptName}";
 
-		// If the OS is Windows, use cmd.exe to run the node executable is cmd file.
-		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-		{
-			exeToRun = "cmd";
-			args = $"/c {pkgManagerCommand} {args}";
-		}
+        // If the OS is Windows, use cmd.exe to run the node executable is cmd file.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            exeToRun = "cmd";
+            args = $"/c {pkgManagerCommand} {args}";
+        }
 
-		// Set the process start info.
-		var psi = new ProcessStartInfo(exeToRun)
-		{
-			Arguments = args,
-			WorkingDirectory = workingDirectory,
-			RedirectStandardInput = true,
-			RedirectStandardOutput = true,
-			RedirectStandardError = true,
-			UseShellExecute = false,
-		};
+        // Set the process start info.
+        var psi = new ProcessStartInfo(exeToRun)
+        {
+            Arguments = args,
+            WorkingDirectory = workingDirectory,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
 
-		// Try to start the process.
-		try
-		{
-			// Create a new process.
+        // Try to start the process.
+        try
+        {
+            // Create a new process.
 			var process = Process.Start(psi) ?? throw new InvalidOperationException($"Unable to start the process '{exeToRun} {args}'.");
-			process.EnableRaisingEvents = true;
-			// Save the process.
-			this._npmProcess = process;
-		}
-		// If an exception is thrown, throw a new exception.
-		catch (Exception ex)
-		{
+            process.EnableRaisingEvents = true;
+            // Save the process.
+            this._npmProcess = process;
+        }
+        // If an exception is thrown, throw a new exception.
+        catch (Exception ex)
+        {
 			var message = $"Unable to start the process '{pkgManagerCommand}'. Make sure the package manager command is installed and available in the PATH.";
-			throw new InvalidOperationException(message, ex);
-		}
+            throw new InvalidOperationException(message, ex);
+        }
 
-		// Create the stream readers.
-		this._stdOutReader = new NodeStreamReader(logger, this._npmProcess.StandardOutput, cancellationToken);
+        // Create the stream readers.
+        this._stdOutReader = new NodeStreamReader(logger, this._npmProcess.StandardOutput, cancellationToken);
 		this._stdErrorReader = new NodeStreamReader(logger, this._npmProcess.StandardError, cancellationToken: cancellationToken);
 
-		cancellationToken.Register(((IDisposable)this).Dispose);
-	}
+        cancellationToken.Register(((IDisposable)this).Dispose);
+    }
 
-	/// <summary>
-	/// The standard output reader.
-	/// </summary>
-	public NodeStreamReader StdOutReader => this._stdOutReader;
+    /// <summary>
+    /// The standard output reader.
+    /// </summary>
+    public NodeStreamReader StdOutReader => this._stdOutReader;
 
-	/// <summary>
-	/// The standard error reader.
-	/// </summary>
+    /// <summary>
+    /// The standard error reader.
+    /// </summary>
 
-	void IDisposable.Dispose()
-	{
-		// If the process is not null, dispose it.
-		if (this._npmProcess != null && !this._npmProcess.HasExited)
-		{
-			this._npmProcess.Kill(entireProcessTree: true);
-			this._npmProcess.Dispose();
-		}
-	}
+    void IDisposable.Dispose()
+    {
+        // If the process is not null, kill it (which disposes as well)
+        if (this._npmProcess != null && !this._npmProcess.HasExited)
+        {
+            this._npmProcess.Kill(entireProcessTree: true);
+        }
+    }
 }


### PR DESCRIPTION
Calling `Kill` and `Dispose` was redundant and caused an exception to get thrown. Calling `Kill` already calls `Dispose` on the process.

😢 I'm sorry for the whitespace changes in the PR.

```
Unhandled exception. System.InvalidOperationException: No process is associated with this object.
   at System.Diagnostics.Process.EnsureState(State state)
   at System.Diagnostics.Process.get_HasExited()
   at Vite.AspNetCore.Utilities.NodeScriptRunner.System.IDisposable.Dispose()
   at Vite.AspNetCore.Services.ViteDevMiddleware.System.IDisposable.Dispose()
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceProviderEngineScope.DisposeAsync()
--- End of stack trace from previous location ---
   at Microsoft.Extensions.Hosting.Internal.Host.<DisposeAsync>g__DisposeAsync|16_0(Object o)
   at Microsoft.Extensions.Hosting.Internal.Host.DisposeAsync()
   at Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.RunAsync(IHost host, CancellationToken token)
   at Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.Run(IHost host)
   at Program.<Main>$(String[] args) in /Users/khalidabuhakmeh/RiderProjects/AspNetCoreLitWebComponents/WebComponents/Program.cs:line 33
```