### PR TITLE
Use TryAdd for registering services

### DIFF
--- a/src/Vite.AspNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Vite.AspNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License, See LICENCE in the project root for license information.
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Vite.AspNetCore.Abstractions;
 using Vite.AspNetCore.Services;
 
@@ -33,11 +34,12 @@ public static class ServiceCollectionExtensions
 		ServiceLifetime optionsLifetime = ServiceLifetime.Singleton)
 		where T : class, IViteManifest
 	{
-		services.AddScoped<ViteStatusService>();
+		services.TryAddScoped<ViteStatusService>();
 		ServiceDescriptor descriptor = new(typeof(IViteManifest), typeof(T), optionsLifetime);
 		services.Add(descriptor);
-		return services.AddSingleton<ViteDevMiddleware>();
-	}
+		services.TryAddSingleton<ViteDevMiddleware>();
+		return services;
+    }
 
 	/// <summary>
 	/// Adds the Vite Middleware service to the service collection.
@@ -48,12 +50,13 @@ public static class ServiceCollectionExtensions
 	{
 		if (!IsStatusServiceAdded)
 		{
-			services.AddScoped<ViteStatusService>();
+			services.TryAddScoped<ViteStatusService>();
 			IsStatusServiceAdded = true;
 		}
 
-		return services.AddSingleton<ViteDevMiddleware>();
-	}
+		services.TryAddSingleton<ViteDevMiddleware>();
+		return services;
+    }
 
 	/// <summary>
 	/// Adds the Vite Manifest Service to the service collection.
@@ -75,7 +78,7 @@ public static class ServiceCollectionExtensions
 	{
 		if (!IsStatusServiceAdded)
 		{
-			services.AddScoped<ViteStatusService>();
+			services.TryAddScoped<ViteStatusService>();
 			IsStatusServiceAdded = true;
 		}
 


### PR DESCRIPTION
Reason for this is that only 1 version will be registered in the services collection container.

Example if a consumer calls `AddViteServices` multiple times then in the current state multiple versions of the same `ViteStatusService` and `ViteDevMiddleware` will be registered, even if they are registered as having a `ServiceLifetime.Singleton`.

It is important to note there is a difference between a lifetime of a service and the version which has been registered in the services collection.

This proposed change, will use the `TryAdd` extension method which only adds a version if it does not exists in the services collection.

See also:  
- [Nick Chapsas - The .NET dependency injection methods you are not using](https://youtu.be/iQ8cNI7a6mk)