### PR TITLE
Allow scripts directory to be specified by user

### DIFF
--- a/src/Vite.AspNetCore/README.md
+++ b/src/Vite.AspNetCore/README.md
@@ -210,19 +210,19 @@ You can also change the configuration for the middleware as follows.
 
 And there are more options that you can change. All the available options are listed below. ⚙️
 
-| Property                       | Description                                                                                                            |
-|--------------------------------|------------------------------------------------------------------------------------------------------------------------|
-| `Vite:Manifest`                | The manifest file name. Default is `manifest.json`.                                                                    |
-| `Vite:Base`                    | The subfolder where your assets will be located, including the manifest file, relative to the web root path.           |
-| `Vite:PackageManager`          | The name of the package manager to use. Default value is `npm`.                                                        |
-| `Vite:Server:AutoRun`          | Enable or disable the automatic start of the Vite Dev Server. Default value is `false`.                                |
-| `Vite:Server:Port`             | The port where the Vite Development Server will be running. Default value is `5173`.                                   |
-| `Vite:Server:Host`             | The host where the Vite Dev Server will be running. Default value is `localhost`.                                      |
-| `Vite:Server:KillPort`         | Use with `Vite:Server:AutoRun` to kill the port before starting the Vite Development Server. Default value is `false`. |
-| `Vite:Server:TimeOut`          | The timeout in seconds spent waiting for the vite dev server. Default is `5`                                           |
-| `Vite:Server:Https`            | If true, the middleware will use HTTPS to connect to the Vite Development Server. Default value is `false`.            |
-| `Vite:Server:ScriptName`       | The script name to run the Vite Development Server. Default value is `dev`.                                            |
-| `Vite:Server:ScriptsDirectory` | The working directory for script execution. Default value is the .NET project working directory.                       |
+| Property                 | Description                                                                                                            |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------|
+| `Vite:Manifest`          | The manifest file name. Default is `manifest.json`.                                                                    |
+| `Vite:Base`              | The subfolder where your assets will be located, including the manifest file, relative to the web root path.           |
+| `Vite:PackageManager`    | The name of the package manager to use. Default value is `npm`.                                                        |
+| `Vite:PackageDirectory`  | The directory where the package.json file is located. Default value is the .NET project working directory.             |
+| `Vite:Server:AutoRun`    | Enable or disable the automatic start of the Vite Dev Server. Default value is `false`.                                |
+| `Vite:Server:Port`       | The port where the Vite Development Server will be running. Default value is `5173`.                                   |
+| `Vite:Server:Host`       | The host where the Vite Dev Server will be running. Default value is `localhost`.                                      |
+| `Vite:Server:KillPort`   | Use with `Vite:Server:AutoRun` to kill the port before starting the Vite Development Server. Default value is `false`. |
+| `Vite:Server:TimeOut`    | The timeout in seconds spent waiting for the vite dev server. Default is `5`                                           |
+| `Vite:Server:Https`      | If true, the middleware will use HTTPS to connect to the Vite Development Server. Default value is `false`.            |
+| `Vite:Server:ScriptName` | The script name to run the Vite Development Server. Default value is `dev`.                                            |
 
 ## Examples
 

--- a/src/Vite.AspNetCore/README.md
+++ b/src/Vite.AspNetCore/README.md
@@ -210,18 +210,19 @@ You can also change the configuration for the middleware as follows.
 
 And there are more options that you can change. All the available options are listed below. ⚙️
 
-| Property                 | Description                                                                                                            |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
-| `Vite:Manifest`          | The manifest file name. Default is `manifest.json`.                                                                    |
-| `Vite:Base`              | The subfolder where your assets will be located, including the manifest file, relative to the web root path.           |
-| `Vite:PackageManager`    | The name of the package manager to use. Default value is `npm`.                                                        |
-| `Vite:Server:AutoRun`    | Enable or disable the automatic start of the Vite Dev Server. Default value is `false`.                                |
-| `Vite:Server:Port`       | The port where the Vite Development Server will be running. Default value is `5173`.                                   |
-| `Vite:Server:Host`       | The host where the Vite Dev Server will be running. Default value is `localhost`.                                      |
-| `Vite:Server:KillPort`   | Use with `Vite:Server:AutoRun` to kill the port before starting the Vite Development Server. Default value is `false`. |
-| `Vite:Server:TimeOut`    | The timeout in seconds spent waiting for the vite dev server. Default is `5`                                           |
-| `Vite:Server:Https`      | If true, the middleware will use HTTPS to connect to the Vite Development Server. Default value is `false`.            |
-| `Vite:Server:ScriptName` | The script name to run the Vite Development Server. Default value is `dev`.                                            |
+| Property                       | Description                                                                                                            |
+|--------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| `Vite:Manifest`                | The manifest file name. Default is `manifest.json`.                                                                    |
+| `Vite:Base`                    | The subfolder where your assets will be located, including the manifest file, relative to the web root path.           |
+| `Vite:PackageManager`          | The name of the package manager to use. Default value is `npm`.                                                        |
+| `Vite:Server:AutoRun`          | Enable or disable the automatic start of the Vite Dev Server. Default value is `false`.                                |
+| `Vite:Server:Port`             | The port where the Vite Development Server will be running. Default value is `5173`.                                   |
+| `Vite:Server:Host`             | The host where the Vite Dev Server will be running. Default value is `localhost`.                                      |
+| `Vite:Server:KillPort`         | Use with `Vite:Server:AutoRun` to kill the port before starting the Vite Development Server. Default value is `false`. |
+| `Vite:Server:TimeOut`          | The timeout in seconds spent waiting for the vite dev server. Default is `5`                                           |
+| `Vite:Server:Https`            | If true, the middleware will use HTTPS to connect to the Vite Development Server. Default value is `false`.            |
+| `Vite:Server:ScriptName`       | The script name to run the Vite Development Server. Default value is `dev`.                                            |
+| `Vite:Server:ScriptsDirectory` | The working directory for script execution. Default value is the .NET project working directory.                       |
 
 ## Examples
 

--- a/src/Vite.AspNetCore/Services/ViteDevMiddleware.cs
+++ b/src/Vite.AspNetCore/Services/ViteDevMiddleware.cs
@@ -65,7 +65,7 @@ public class ViteDevMiddleware : IMiddleware, IDisposable
 			// Gets the package manager command.
 			var pkgManagerCommand = this._viteOptions.PackageManager;
 			// Gets the working directory.
-			var workingDirectory = this._viteOptions.Server.ScriptsDirectory ?? environment.ContentRootPath;
+			var workingDirectory = this._viteOptions.PackageDirectory ?? environment.ContentRootPath;
 			// Gets the script name.= to run the Vite Dev Server.
 			var scriptName = this._viteOptions.Server.ScriptName;
 

--- a/src/Vite.AspNetCore/Services/ViteDevMiddleware.cs
+++ b/src/Vite.AspNetCore/Services/ViteDevMiddleware.cs
@@ -65,7 +65,7 @@ public class ViteDevMiddleware : IMiddleware, IDisposable
 			// Gets the package manager command.
 			var pkgManagerCommand = this._viteOptions.PackageManager;
 			// Gets the working directory.
-			var workingDirectory = environment.ContentRootPath;
+			var workingDirectory = this._viteOptions.Server.ScriptsDirectory ?? environment.ContentRootPath;
 			// Gets the script name.= to run the Vite Dev Server.
 			var scriptName = this._viteOptions.Server.ScriptName;
 

--- a/src/Vite.AspNetCore/ViteOptions.cs
+++ b/src/Vite.AspNetCore/ViteOptions.cs
@@ -25,6 +25,12 @@ public record ViteOptions
 	/// The name of the package manager to use. Default value is "npm".
 	/// </summary>
 	public string PackageManager { get; init; } = "npm";
+    
+    /// <summary>
+    /// The directory where the package.json file is located.
+    /// Default value is the .NET project working directory.
+    /// </summary>
+    public string? PackageDirectory { get; init; }
 
 	/// <summary>
 	/// Options for the Vite Dev Server.

--- a/src/Vite.AspNetCore/ViteServerOptions.cs
+++ b/src/Vite.AspNetCore/ViteServerOptions.cs
@@ -44,4 +44,10 @@ public record ViteServerOptions
 	/// The script name to run the Vite Dev Server. Default value is "dev".
 	/// </summary>
 	public string ScriptName { get; init; } = "dev";
+    
+    /// <summary>
+    /// The working directory for script execution.
+    /// Default value is the .NET project working directory.
+    /// </summary>
+    public string? ScriptsDirectory { get; init; }
 }

--- a/src/Vite.AspNetCore/ViteServerOptions.cs
+++ b/src/Vite.AspNetCore/ViteServerOptions.cs
@@ -44,10 +44,4 @@ public record ViteServerOptions
 	/// The script name to run the Vite Dev Server. Default value is "dev".
 	/// </summary>
 	public string ScriptName { get; init; } = "dev";
-    
-    /// <summary>
-    /// The working directory for script execution.
-    /// Default value is the .NET project working directory.
-    /// </summary>
-    public string? ScriptsDirectory { get; init; }
 }


### PR DESCRIPTION
### Motivation
While working on the project, I found it could be beneficial to isolate npm/node/vite-related resources in a separate `./frontend` directory. This setup allows a clear divide between backend and frontend, particularly useful since we're utilizing Vite to integrate client-side interactivity. After adjusting paths in `vite.config.js` and `.csproj`, everything functioned smoothly except `AutoRun`.

### Proposed Update
You now have the option to move your npm/node/vite files into a directory of your choice by modifying the "ScriptsDirectory" property in appsettings. If no directory is specified, the scripts will automatically use the current path (environment.ContentRootPath) to ensure consistent system operation.

Looking forward to hearing your feedback on this update.