### PR TITLE
Forgotten 'using' statement for HttpClient

### DIFF
--- a/src/Vite.AspNetCore/Services/ViteDevMiddleware.cs
+++ b/src/Vite.AspNetCore/Services/ViteDevMiddleware.cs
@@ -181,7 +181,7 @@ public class ViteDevMiddleware : IMiddleware, IDisposable
 	private async Task ProxyAsync(HttpContext context, RequestDelegate next, string path)
 	{
 		// Initialize a "new" instance of the HttpClient class via the HttpClientFactory.
-		var client = _clientFactory.CreateClient();
+		using var client = _clientFactory.CreateClient();
 		client.BaseAddress = new Uri(this._viteServerBaseUrl);
 
 		// Pass "Accept" header from the original request.


### PR DESCRIPTION
The 'using' statement was added to ensure proper disposal of the HttpClient instance after usage. The HttpClient instance created by the HttpClientFactory is now wrapped within a 'using' declaration, enforcing the Dispose pattern as soon as the object goes out of scope, which was missing in the previous PR