### PR TITLE
Ensure consistent path separators

### DIFF
--- a/src/Vite.AspNetCore/Services/ViteManifest.cs
+++ b/src/Vite.AspNetCore/Services/ViteManifest.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Text.Json;
 using Vite.AspNetCore.Abstractions;
+using Vite.AspNetCore.Utilities;
 
 namespace Vite.AspNetCore.Services;
 
@@ -56,7 +57,7 @@ public sealed class ViteManifest : IViteManifest
 		this._base = viteOptions.Base?.TrimStart('/');
 
 		// Get the manifest.json file path
-		var manifestPath = Path.Combine(environment.WebRootPath, this._base ?? "", manifest);
+		var manifestPath = PathUtils.PathCombine(environment.WebRootPath, this._base ?? "", manifest);
 
 		// If the manifest.json file exists, deserialize it into a dictionary.
 		if (File.Exists(manifestPath))
@@ -77,17 +78,17 @@ public sealed class ViteManifest : IViteManifest
 				foreach (var chunk in this._chunks)
 				{
 					// Add the base path to the key.
-					var key = Path.Combine(this._base, chunk.Key);
+					var key = PathUtils.PathCombine(this._base, chunk.Key);
 
 					// Add the base path to the value.
 					var value = chunk.Value with
 					{
-						Css = chunk.Value.Css?.Select(css => Path.Combine(this._base, css)),
-						File = Path.Combine(this._base, chunk.Value.File),
-						Imports = chunk.Value.Imports?.Select(imports => Path.Combine(this._base, imports)),
-						Src = string.IsNullOrEmpty(chunk.Value.Src) ? null : Path.Combine(this._base, chunk.Value.Src),
-						Assets = chunk.Value.Assets?.Select(assets => Path.Combine(this._base, assets)),
-						DynamicImports = chunk.Value.DynamicImports?.Select(dynamicImports => Path.Combine(this._base, dynamicImports)),
+						Css = chunk.Value.Css?.Select(css => PathUtils.PathCombine(this._base, css)),
+						File = PathUtils.PathCombine(this._base, chunk.Value.File),
+						Imports = chunk.Value.Imports?.Select(imports => PathUtils.PathCombine(this._base, imports)),
+						Src = string.IsNullOrEmpty(chunk.Value.Src) ? null : PathUtils.PathCombine(this._base, chunk.Value.Src),
+						Assets = chunk.Value.Assets?.Select(assets => PathUtils.PathCombine(this._base, assets)),
+						DynamicImports = chunk.Value.DynamicImports?.Select(dynamicImports => PathUtils.PathCombine(this._base, dynamicImports)),
 						IsDynamicEntry = chunk.Value.IsDynamicEntry,
 						IsEntry = chunk.Value.IsEntry,
 					};

--- a/src/Vite.AspNetCore/TagHelpers/ViteTagHelper.cs
+++ b/src/Vite.AspNetCore/TagHelpers/ViteTagHelper.cs
@@ -10,6 +10,7 @@ using System.ComponentModel;
 using System.Text.RegularExpressions;
 using Vite.AspNetCore.Abstractions;
 using Vite.AspNetCore.Services;
+using Vite.AspNetCore.Utilities;
 
 namespace Vite.AspNetCore.TagHelpers;
 
@@ -121,6 +122,9 @@ public class ViteTagHelper : TagHelper
 		{
 			// Removes the leading '~/' from the value. This is needed because the manifest file doesn't contain the leading '~/' or '/'.
 			value = value.TrimStart('~', '/');
+            
+            // Ensure consistent path separators
+            value = PathUtils.PathCombine(value);
 
 			// Get the entry chunk from the 'manifest.json' file.
 			var entry = this._manifest[value];

--- a/src/Vite.AspNetCore/Utilities/PathUtils.cs
+++ b/src/Vite.AspNetCore/Utilities/PathUtils.cs
@@ -1,0 +1,21 @@
+namespace Vite.AspNetCore.Utilities;
+
+public static class PathUtils
+{
+    private static readonly char[] PathSeparators = { '/', '\\' };
+    
+    /// <summary>
+    /// Combines multiple paths into a single path with normalized separators.
+    /// This method is similar to <see cref="Path.Combine(string,string)"/>, which doesn't normalize the separators.
+    /// </summary>
+    /// <param name="paths">The paths to be combined.</param>
+    /// <returns>The combined path with normalized separators.</returns>
+    public static string PathCombine(params string[] paths)
+    {
+        // Split the paths into segments
+        var segments = paths.SelectMany(s => s.Split(PathSeparators));
+        
+        // Join the segments using the platform-specific path separator
+        return Path.Combine(segments.ToArray());
+    }
+}


### PR DESCRIPTION
When using the `Vite:Base` setting the path is combined with the manifest key using `Path.Combine`. On Windows this results in path like this; `dist\main.ts`, otherwise `dist/main.ts`.

And from the script tag, we get a path like `~/dist/main.ts` which gets sanitized to `dist/main.ts`, but the path separators are untouched. This is a problem when running on Windows.

Here is the result, we cannot access the manifest chunk:
![image](https://github.com/Eptagone/Vite.AspNetCore/assets/5948752/a6111aae-66d1-449e-8e4f-0624ac7d5631)

This PR replaces `Path.Combine` with `PathUtils.PathCombine` in `src/Vite.AspNetCore/Services/ViteManifest.cs` for cases where `Vite:Base` contains path separators. And `PathUtils.PathCombine` is introduced in `src/Vite.AspNetCore/TagHelpers/ViteTagHelper.cs` to give the script tag input the path separator normalization treatment.

`Path.Combine` with `PathUtils.PathCombine` does generally the same thing except `PathUtils.PathCombine` also does path separator normalization.


