### PR TITLE
Combine relative PackageDirectory path with the ContentRootPath

### DIFF
--- a/src/Vite.AspNetCore/Services/ViteServerLaunchManager.cs
+++ b/src/Vite.AspNetCore/Services/ViteServerLaunchManager.cs
@@ -54,10 +54,10 @@ namespace Vite.AspNetCore.Services
 			// Set the working directory.
 			var workingDirectory = this._options.PackageDirectory ?? this._environment.ContentRootPath;
 
-			// If the working directory is relative, combine it with the app's base directory.
+			// If the working directory is relative, combine it with the app's content root directory.
 			if (!Path.IsPathRooted(workingDirectory))
 			{
-				workingDirectory = Path.Combine(AppContext.BaseDirectory, workingDirectory);
+				workingDirectory = Path.Combine(this._environment.ContentRootPath, workingDirectory);
 			}
 
 			// Create the process start info.


### PR DESCRIPTION
When specifying the `PackageDirectory` property in ViteOptions, treat non-rooted directory paths as though they are relative to the `IWebHostEnvironment.ContentRootPath`. This path will be the Project directory when running during development.

Fixes #44 

I tested this with a project structure like below, where the Vite client application (both package.json and vite.config.js) are within a child folder of the package directory:

```
AspNetProject/
├─ ClientApp/
│  ├─ package.json
│  ├─ vite.config.js/
│  ├─ main.js
├─ AspNetProject.csproj/
├─ Program.cs/
```

I also tested with a folder structure that has the Vite client application outside the project directory entirely (similar to Webcoda's project in the bug report).

```
ClientApp/
├─ package.json
├─ vite.config.js/
├─ main.js
AspNetProject/
├─ AspNetProject.csproj/
├─ Program.cs/

```

