### PR TITLE
Add react-refresh in dev mode

### DIFF
--- a/examples/basic/frameworks/ViteNET.React/Pages/Shared/_Layout.cshtml
+++ b/examples/basic/frameworks/ViteNET.React/Pages/Shared/_Layout.cshtml
@@ -18,16 +18,6 @@
 		@RenderBody()
 	</main>
 
-	@* Required for React Refresh *@
-	<environment include="Development">
-		<script type="module">
-			import RefreshRuntime from '@ViteDevServerStatus.ServerUrl/@@react-refresh'
-			RefreshRuntime.injectIntoGlobalHook(window)
-			window.$RefreshReg$ = () => { }
-			window.$RefreshSig$ = () => (type) => type
-			window.__vite_plugin_react_preamble_installed__ = true
-		</script>
-	</environment>
 	<!-- This line includes your "main.ts" entrypoint -->
 	<script type="module" vite-src="~/main.tsx"></script>
 

--- a/examples/basic/frameworks/ViteNET.React/appsettings.json
+++ b/examples/basic/frameworks/ViteNET.React/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "Vite": {
+    "UseReactRefresh": true
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/Vite.AspNetCore/README.md
+++ b/src/Vite.AspNetCore/README.md
@@ -229,19 +229,20 @@ If you prefer not to hardcode the options, you can use environment variables or 
 
 There are more options that you can change. All the available options are listed below. ⚙️
 
-| Property               | Description                                                                                                  |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `Manifest`             | The manifest file name. Default is `.vite/manifest.json` (Vite 5) or `manifest.json` (Vite 4).               |
-| `Base`                 | The subfolder where your assets will be located, including the manifest file, relative to the web root path. |
-| `PackageManager`       | The name of the package manager to use. Default value is `npm`.                                              |
-| `PackageDirectory`     | The directory where the package.json file is located. Default value is the .NET project working directory.   |
-| `Server:AutoRun`       | Enable or disable the automatic start of the Vite Dev Server. Default value is `false`.                      |
-| `Server:Port`          | The port where the Vite Development Server will be running. Default value is `5173`.                         |
-| `Server:Host`          | The host where the Vite Dev Server will be running. Default value is `localhost`.                            |
-| `Server:TimeOut`       | The timeout in seconds spent waiting for the vite dev server. Default is `5`                                 |
-| `Server:Https`         | If true, the middleware will use HTTPS to connect to the Vite Development Server. Default value is `false`.  |
-| `Server:ScriptName`    | The script name to run the Vite Development Server. Default value is `dev`.                                  |
-| `Server:UseFullDevUrl` | If true, tag helpers will use the full dev server URL instead of just paths. Default value is `false`.       |
+| Property               | Description                                                                                                     |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------  |
+| `Manifest`             | The manifest file name. Default is `.vite/manifest.json` (Vite 5) or `manifest.json` (Vite 4).                  |
+| `Base`                 | The subfolder where your assets will be located, including the manifest file, relative to the web root path.    |
+| `PackageManager`       | The name of the package manager to use. Default value is `npm`.                                                 |
+| `PackageDirectory`     | The directory where the package.json file is located. Default value is the .NET project working directory.      |
+| `UseReactRefresh`      | `true` for loading the react-refresh when loading the vite client while developing to enable HMR. |
+| `Server:AutoRun`       | Enable or disable the automatic start of the Vite Dev Server. Default value is `false`.                         |
+| `Server:Port`          | The port where the Vite Development Server will be running. Default value is `5173`.                            |
+| `Server:Host`          | The host where the Vite Dev Server will be running. Default value is `localhost`.                               |
+| `Server:TimeOut`       | The timeout in seconds spent waiting for the vite dev server. Default is `5`                                    |
+| `Server:Https`         | If true, the middleware will use HTTPS to connect to the Vite Development Server. Default value is `false`.     |
+| `Server:ScriptName`    | The script name to run the Vite Development Server. Default value is `dev`.                                     |
+| `Server:UseFullDevUrl` | If true, tag helpers will use the full dev server URL instead of just paths. Default value is `false`.          |
 
 > If you are using the `appsettings.json` and/or `appsettings.Development.json` files, all the options must be under the `Vite` property.
 

--- a/src/Vite.AspNetCore/ViteOptions.cs
+++ b/src/Vite.AspNetCore/ViteOptions.cs
@@ -33,6 +33,12 @@ public record ViteOptions
 	public string? PackageDirectory { get; set; }
 
 	/// <summary>
+	/// Inject the react-refresh preamble and enable HMR for React components, see: https://vitejs.dev/guide/backend-integration.html.
+	/// Default value is false.
+	/// </summary>
+	public bool? UseReactRefresh { get; set; }
+
+	/// <summary>
 	/// Options for the Vite Dev Server.
 	/// </summary>
 	public ViteServerOptions Server { get; set; } = new ViteServerOptions();


### PR DESCRIPTION
I've had to manually add the react-refresh module in my project. This injects the React-Refresh module and the required preamble while also respecting the port set in the config circumventing the client being loaded twice (due to port problems) and doing HMR twice.