### PR TITLE
HMR proxy for ViteDevMiddleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ builder.Services.AddViteServices();
 // Use the Vite Development Server in development environment.
 if (app.Environment.IsDevelopment())
 {
+    // If you use the integrated middleware (see next line) and your app
+    // has not added WebSockets earlier in the pipeline, you need to add it
+    // to support HMR (hot module reload).
+    /* app.UseWebSockets(); */
     // Enable all required features to use the Vite Development Server.
     // Pass true if you want to use the integrated middleware.
     app.UseViteDevelopmentServer(/* false */);

--- a/src/Vite.AspNetCore/README.md
+++ b/src/Vite.AspNetCore/README.md
@@ -38,8 +38,11 @@ builder.Services.AddViteServices();
 // Use Middleware in development environment.
 if (app.Environment.IsDevelopment())
 {
+    // WebSockets support is required for HMR (hot module reload).
+    // This call is redundant if your pipeline already contains it.
+    app.UseWebSockets();
     // Enable the Middleware to use the Vite Development Server.
-    app.UseViteDevMiddleware();
+    app.UseViteDevMiddleware(true);
 }
 ```
 

--- a/src/Vite.AspNetCore/Services/ViteDevHmrProxy.cs
+++ b/src/Vite.AspNetCore/Services/ViteDevHmrProxy.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) 2024 Quetzal Rivera.
+// Licensed under the MIT License, See LICENCE in the project root for license information.
+
+using System.Net.WebSockets;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.Extensions.Logging;
+
+namespace Vite.AspNetCore.Services;
+
+/// <summary>
+/// WebSocket bi-directional proxy for Vite HMR.
+/// </summary>
+/// <param name="logger">The logger service.</param>
+internal class ViteDevHmrProxy(ILogger logger)
+{
+	internal const string SubProtocol = "vite-hmr";
+
+	private readonly ILogger logger = logger;
+
+	/// <summary>
+	/// Proxies the HMR WebSocket request to the Vite Dev Server.
+	/// </summary>
+	/// <param name="context">The <see cref="HttpContext"/> instance.</param>
+	/// <param name="targetUri">Vite server HMR WebSocket address. Must use 'ws' or 'wss' <see cref="Uri.Scheme"/>.</param>
+	/// <param name="cancellationToken">Cancellation token.</param>
+	/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+	internal async Task ProxyAsync(HttpContext context, Uri targetUri, CancellationToken cancellationToken)
+	{
+		var clientUri = new Uri(context.Request.GetDisplayUrl());
+		this.logger.LogInformation("Establishing HMR WebSocket proxy: {ClientWebSocketUri} -> {TargetWebSocketUri}", clientUri, targetUri);
+
+		ClientWebSocket? targetWebSocket = null;
+		WebSocket? clientWebSocket = null;
+
+		try
+		{
+			targetWebSocket = new ClientWebSocket();
+			targetWebSocket.Options.AddSubProtocol(SubProtocol);
+			await targetWebSocket.ConnectAsync(targetUri, cancellationToken);
+			if (targetWebSocket.State != WebSocketState.Open)
+			{
+				throw new WebSocketException(WebSocketError.InvalidState, $"Target WebSocket's state is {targetWebSocket.State}");
+			}
+
+			clientWebSocket = await context.WebSockets.AcceptWebSocketAsync(SubProtocol);
+			if (clientWebSocket.State != WebSocketState.Open)
+			{
+				throw new WebSocketException(WebSocketError.InvalidState, $"Client WebSocket's state is {clientWebSocket.State}");
+			}
+
+			// two parallel tasks will be used to send and receive data in both directions.
+			// the direction to be closed first is undefined, so we introduce a special token to stop the other one.
+			var transceiveCancellationTokenSource = new CancellationTokenSource();
+			var transceiveCancellationToken = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, transceiveCancellationTokenSource.Token).Token;
+
+			var tcTransceiveTask = Transceive(targetWebSocket, clientWebSocket, transceiveCancellationToken);
+			var ctTransceiveTask = Transceive(clientWebSocket, targetWebSocket, transceiveCancellationToken);
+
+			try
+			{
+				// run until any of them finishes
+				await Task.WhenAny(tcTransceiveTask, ctTransceiveTask);
+				// stop the second task if it's still running
+				transceiveCancellationTokenSource.Cancel();
+				// if none reacted to cancellation, though it's hardly possible irl
+				await Task.WhenAll(tcTransceiveTask, ctTransceiveTask);
+			}
+			catch (TaskCanceledException)
+			{
+				// not a problem: thrown in case of cancellation
+			}
+		}
+		catch (Exception e)
+		{
+			this.logger.LogError(e, "HMR WebSocket proxy error");
+			context.Abort();
+		}
+		finally
+		{
+			await CloseIfOpen(targetWebSocket, targetUri, cancellationToken);
+			await CloseIfOpen(clientWebSocket, clientUri, cancellationToken);
+			targetWebSocket?.Dispose();
+			clientWebSocket?.Dispose();
+		}
+	}
+
+	private async Task Transceive(WebSocket source, WebSocket destination, CancellationToken cancellationToken)
+	{
+		var buffer = new byte[1024 * 4];
+
+		var sourceReceiveResult = await Receive(source);
+		while (true)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+
+			if (sourceReceiveResult.CloseStatus.HasValue ||
+				destination.State != WebSocketState.Open)
+				return;
+
+			await Send(sourceReceiveResult, destination);
+			sourceReceiveResult = await Receive(source);
+		}
+
+		Task<WebSocketReceiveResult> Receive(WebSocket webSocket)
+			=> webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken);
+
+		Task Send(WebSocketReceiveResult result, WebSocket webSocket)
+			=> webSocket.SendAsync(
+				new ArraySegment<byte>(buffer, 0, result.Count),
+				result.MessageType,
+				result.EndOfMessage,
+				cancellationToken);
+	}
+
+	private async Task CloseIfOpen(WebSocket? ws, Uri uri, CancellationToken cancellationToken)
+	{
+		if (ws == null || ws.State != WebSocketState.Open) return;
+
+		try
+		{
+			await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancellationToken);
+		}
+		catch (Exception e)
+		{
+			this.logger.LogWarning(e, "Failed to close WebSocket {WebSocketUri}", uri);
+		}
+	}
+}


### PR DESCRIPTION
[Vite's docs](https://vitejs.dev/config/server-options#server-hmr) state that:

> With the default configuration, reverse proxies in front of Vite are expected to support proxying WebSocket. If the Vite HMR client fails to connect WebSocket, the client will fall back to connecting the WebSocket directly to the Vite HMR server bypassing the reverse proxies

If the `server` section is absent in vite.config.js then the fall back logic fails (tested in v5.0.10) - it retries connection using the "ws://localhost:undefined/" URI.  As a result, enabling HMR currently requires explicit configuration:

```js
export default defineConfig({
  server: {
    port: 5173,
    strictPort: true,
    hmr: {
      port: 5173,
    },
  },
}
```

This looks like a bug of Vite to me (I would have used the same default server port for HMR fall back), but I've anyway implemented the solution they describe as expected.

If a WebSocket request contains the appropriate subprotocol then `ViteDevMiddleware` delegates it to a minimalistic WS proxy `ViteDevHmrProxy`.

Unfortunately I haven't found any good method to check if `UseWebSockets()` has already been used during pipeline configuration, so I've also mentioned this call in READMEs.