### PR TITLE
Add Config Priority blurp to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ If you prefer not to hardcode the options, you can use environment variables or 
 
 > In the previous example, i used the `appsettings.json` and `appsettings.Development.json` files to keep the configurations for each environment separated. But you can use only one file if you prefer.
 
+> Config mechanisms are exclusive to each other and can't be mixed. Service configuration has priority load over Environment Variable configuration.
+
 ### Available Options
 
 There are more options that you can change. All the available options are listed below. ⚙️

--- a/src/Vite.AspNetCore/README.md
+++ b/src/Vite.AspNetCore/README.md
@@ -230,6 +230,9 @@ If you prefer not to hardcode the options, you can use environment variables or 
 
 > In the previous example, i used the `appsettings.json` and `appsettings.Development.json` files to keep the configurations for each environment separated. But you can use only one file if you prefer.
 
+> If you are using the `appsettings.json` and/or `appsettings.Development.json` files, all the options must be under the `Vite` property.
+
+
 ### Available Options
 
 There are more options that you can change. All the available options are listed below. ⚙️


### PR DESCRIPTION
I ran into this while debugging my setup, and accidentally mixed both Service & Environment Config. As those errors go, it took me way longer than I want to admit to find the issue. Hopefully this small hint saves somebody some time.

The underlying issue is that hard-coded configuration takes priority over config in the `appsettings.json` files.
I.E. I configure `Server.AutoRun` etc in appsettings.json, and `Manifest` in the `Program.cs`, only the config from `Program.cs` will be loaded. 