### PR TITLE
Fix an issue with ViteTagHelper where 'as' attribute is ignored

### DIFF
--- a/src/Vite.AspNetCore/TagHelpers/ViteTagHelper.cs
+++ b/src/Vite.AspNetCore/TagHelpers/ViteTagHelper.cs
@@ -37,7 +37,7 @@ public class ViteTagHelper(
 
     private const string VITE_HREF_ATTRIBUTE = "vite-href";
     private const string VITE_SRC_ATTRIBUTE = "vite-src";
-    private const string LINK_AS_ATTRIBUTE = "stylesheet";
+    private const string LINK_AS_ATTRIBUTE = "as";
     private const string LINK_AS_STYLE = "style";
     private const string LINK_REL_ATTRIBUTE = "rel";
     private const string LINK_REL_STYLESHEET = "stylesheet";


### PR DESCRIPTION
Fix the constant string "LINK_AS_ATTRIBUTE" on `ViteTagHelper`, allowing the use of link elements with rel="preload"

Fixes #126.